### PR TITLE
forcefully output in .json, regardless of requested mode

### DIFF
--- a/src/main/java/com/hermanoid/nerd/RecipeDumper.java
+++ b/src/main/java/com/hermanoid/nerd/RecipeDumper.java
@@ -125,12 +125,7 @@ public class RecipeDumper extends DataDumper {
 
     @Override
     public void dumpTo(File file) {
-        // Allow both 1 and 0... I dunno why but if you're running debug the mode is 1 and if you run with the full
-        // GTNH modpack it's 0.
-        // Instead of solving it, we ignore it (big brain)
-        if (getMode() != 1 && getMode() != 0) {
-            throw new RuntimeException("RecipeDumper received an unexpected mode! There should only be one mode: JSON");
-        }
+        // Always dump JSON, regardless of mode
         dumpJson(file);
     }
 

--- a/src/main/java/com/hermanoid/nerd/stack_serialization/RecipeDumpContext.java
+++ b/src/main/java/com/hermanoid/nerd/stack_serialization/RecipeDumpContext.java
@@ -1,7 +1,12 @@
 package com.hermanoid.nerd.stack_serialization;
 
 import java.lang.reflect.Type;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;


### PR DESCRIPTION
I guess temporally fix, but it works on GTNH 2.8.0-beta-1